### PR TITLE
Convert to using local volume (vs container volume)

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,3 @@
+# This directory is for data and should not contain any files tracked by the repository
+*
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,4 @@ services:
     environment:
       - NODE_ENV=production  # Set the environment variable to production
     volumes:
-      - sqlite_data:/app/data  # Mount the volume for your SQLite database
-
-volumes:
-  sqlite_data:  # Define the volume for persistent SQLite storage
+      - ./data:/app/data  # Mount the volume for your SQLite database


### PR DESCRIPTION
This change maps the host's data directory into the container. This means the database file will be created on the host system and will persist even across container rebuilds.